### PR TITLE
fix: reduce account history pageSize from 1000 to 100

### DIFF
--- a/config/custom-environment-variables.toml
+++ b/config/custom-environment-variables.toml
@@ -19,3 +19,6 @@ dialect = 'DATABASE_DIALECT'
 ttl = 'CACHE_CLIENT_TTL'
 interval = 'CACHE_CLIENT_CHECK_INTERVAL'
 accounts_refresh_intercal = 'ACCOUNTS_REFRESH_INTERVAL'
+
+[accountHistory]
+pageSize = 'ACCOUNT_HISTORY_PAGE_SIZE'

--- a/config/default.toml
+++ b/config/default.toml
@@ -38,3 +38,6 @@ operatorsAliases = false
 ttl = 600
 interval = 60
 
+[accountHistory]
+pageSize = 100
+

--- a/config/production.toml
+++ b/config/production.toml
@@ -15,3 +15,6 @@ ssl = true
 [cacheClient]
 ttl = 600
 interval = 60
+
+[accountHistory]
+pageSize = 100

--- a/src/user-search/client.ts
+++ b/src/user-search/client.ts
@@ -13,6 +13,9 @@ const CACHE_CLIENT_TTL: number = config.get('cacheClient')['ttl']
 const CACHE_CLIENT_CHECK_INTERVAL: number = config.get('cacheClient')[
     'interval'
 ]
+const ACCOUNT_HISTORY_PAGE_SIZE: number = config.has('accountHistory.pageSize')
+    ? config.get('accountHistory')['pageSize']
+    : 100
 enum FollowType {
     undefined,
     blog,
@@ -50,7 +53,7 @@ interface AccountHistoryPair {
 }
 
 export class CachingClient {
-    private readonly pageSize: number = 1000
+    private readonly pageSize: number = ACCOUNT_HISTORY_PAGE_SIZE
 
     constructor(
         public readonly cache?: any,


### PR DESCRIPTION
jussi (gateway) enforces a max limit of 100 for `get_account_history`.
The hard-coded pageSize of 1000 causes every request to fail with:
`Account History request exceeded limit. The max limit is 100. Your limit is 10000`

Changes:
- Make pageSize configurable via `accountHistory.pageSize` (default 100)
- Support `ACCOUNT_HISTORY_PAGE_SIZE` env var override
- Update default.toml and production.toml with pageSize = 100