### PR TITLE
M4: conveyor.get_prices via steemgosdk + ComputePrices

### DIFF
--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -1,0 +1,104 @@
+// Package prices implements the conveyor.get_prices RPC method, mirroring the
+// original TS src/price.ts. It fetches order book, feed history, and dynamic
+// global properties from steemd in parallel, then uses steemutil's ComputePrices
+// (int64 + math/big arithmetic) to derive the three price values.
+package prices
+
+import (
+	"sync"
+
+	"github.com/steemit/steemgosdk/api"
+	protocolapi "github.com/steemit/steemutil/protocol/api"
+
+	"github.com/steemit/conveyor/internal/jsonrpc"
+)
+
+// Prices holds the steemd API client used to fetch market data.
+type Prices struct {
+	api *api.API
+}
+
+// New creates a Prices instance backed by the given Steem RPC node.
+func New(rpcNode string) *Prices {
+	return &Prices{api: api.NewAPI(rpcNode)}
+}
+
+// Register registers the conveyor.get_prices method (public, no auth).
+func (p *Prices) Register(rpc *jsonrpc.Server) {
+	rpc.Register("conveyor.get_prices", p.GetPrices)
+}
+
+// pricesResponse is the JSON-RPC result shape, matching the schema's
+// "prices" definition: three float64 fields.
+type pricesResponse struct {
+	SteemSbd  float64 `json:"steem_sbd"`
+	SteemUsd  float64 `json:"steem_usd"`
+	SteemVest float64 `json:"steem_vest"`
+}
+
+func (p *Prices) GetPrices(ctx *jsonrpc.Context, req *jsonrpc.Request) (any, error) {
+	// Fetch the three data sources in parallel (matching TS Promise.all).
+	var (
+		ob  *protocolapi.OrderBook
+		fh  *protocolapi.FeedHistory
+		dgp *protocolapi.DynamicGlobalProperties
+		obErr, fhErr, dgpErr error
+		wg  sync.WaitGroup
+	)
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		ob, obErr = p.api.GetOrderBook(1)
+	}()
+	go func() {
+		defer wg.Done()
+		fh, fhErr = p.api.GetFeedHistory()
+	}()
+	go func() {
+		defer wg.Done()
+		dgp, dgpErr = p.api.GetDynamicGlobalProperties()
+	}()
+	wg.Wait()
+
+	if obErr != nil {
+		return nil, jsonrpc.ErrInternalError(obErr)
+	}
+	if fhErr != nil {
+		return nil, jsonrpc.ErrInternalError(fhErr)
+	}
+	if dgpErr != nil {
+		return nil, jsonrpc.ErrInternalError(dgpErr)
+	}
+
+	// Compute prices using steemutil's integer-arithmetic implementation.
+	result, err := protocolapi.ComputePrices(ob, fh, dgp)
+	if err != nil {
+		return nil, jsonrpc.ErrInternalError(err)
+	}
+
+	// Convert int64 atomic units to float64 display values.
+	//
+	// SteemSbd: already the averaged conversion result (Asset), divide by
+	//   10^3 (SBD precision).
+	// SteemUsd: a raw Price (not pre-converted). Must Convert(1 STEEM) to get
+	//   the SBD amount, then divide by 10^3.
+	// SteemVest: a raw Price. Must Convert(1 STEEM) to get the VESTS amount,
+	//   then divide by 10^6 (VESTS precision).
+	oneSteem := protocolapi.Asset{Amount: 1000, Symbol: "STEEM"} // 1.000 STEEM
+
+	usdAsset, err := result.SteemUsd.Convert(oneSteem)
+	if err != nil {
+		return nil, jsonrpc.ErrInternalError(err)
+	}
+	vestAsset, err := result.SteemVest.Convert(oneSteem)
+	if err != nil {
+		return nil, jsonrpc.ErrInternalError(err)
+	}
+
+	return pricesResponse{
+		SteemSbd:  float64(result.SteemSbd.Amount) / 1e3,
+		SteemUsd:  float64(usdAsset.Amount) / 1e3,
+		SteemVest: float64(vestAsset.Amount) / 1e6,
+	}, nil
+}

--- a/internal/prices/prices_test.go
+++ b/internal/prices/prices_test.go
@@ -13,8 +13,7 @@ import (
 // reasonable values. This tests the core math without needing a live steemd.
 func TestComputePrices_Conversion(t *testing.T) {
 	// Fixture: 1 ask + 1 bid (matching TS limit=1).
-	// Ask: someone selling STEEM for SBD at 1:0.5 (base=5.000 SBD, quote=10.000 STEEM)
-	// Bid: someone buying STEEM with SBD at the same ratio.
+	// Both at 0.500 SBD per 1.000 STEEM.
 	ob := &protocolapi.OrderBook{
 		Asks: []protocolapi.Order{
 			{OrderPrice: protocolapi.OrderPrice{Base: "0.500 SBD", Quote: "1.000 STEEM"}},

--- a/internal/prices/prices_test.go
+++ b/internal/prices/prices_test.go
@@ -1,0 +1,89 @@
+package prices
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	protocolapi "github.com/steemit/steemutil/protocol/api"
+)
+
+// TestComputePrices_Conversion verifies that ComputePrices produces sane
+// results from fixture data, and that the int64 → float64 conversion produces
+// reasonable values. This tests the core math without needing a live steemd.
+func TestComputePrices_Conversion(t *testing.T) {
+	// Fixture: 1 ask + 1 bid (matching TS limit=1).
+	// Ask: someone selling STEEM for SBD at 1:0.5 (base=5.000 SBD, quote=10.000 STEEM)
+	// Bid: someone buying STEEM with SBD at the same ratio.
+	ob := &protocolapi.OrderBook{
+		Asks: []protocolapi.Order{
+			{OrderPrice: protocolapi.OrderPrice{Base: "0.500 SBD", Quote: "1.000 STEEM"}},
+		},
+		Bids: []protocolapi.Order{
+			{OrderPrice: protocolapi.OrderPrice{Base: "0.500 SBD", Quote: "1.000 STEEM"}},
+		},
+	}
+
+	fh := &protocolapi.FeedHistory{
+		PriceHistory: []protocolapi.CurrentMedianHistoryPrice{
+			{Base: "0.500 SBD", Quote: "1.000 STEEM"},
+		},
+	}
+
+	dgp := &protocolapi.DynamicGlobalProperties{
+		TotalVestingFundSteem: "100.000 STEEM",
+		TotalVestingShares:    "4200000.000000 VESTS",
+	}
+
+	result, err := protocolapi.ComputePrices(ob, fh, dgp)
+	if err != nil {
+		t.Fatalf("ComputePrices failed: %v", err)
+	}
+
+	// steem_sbd: mean of Convert(1 STEEM) over 2 orders, each yielding 0.500 SBD.
+	// → 500 (atomic, 3 decimals) → 0.5 float.
+	sbd := float64(result.SteemSbd.Amount) / 1e3
+	if sbd != 0.5 {
+		t.Errorf("steem_sbd: expected 0.5, got %f (raw=%d)", sbd, result.SteemSbd.Amount)
+	}
+
+	// steem_usd: Price 0.500 SBD / 1.000 STEEM, convert 1 STEEM → 0.500 SBD.
+	oneSteem := protocolapi.Asset{Amount: 1000, Symbol: "STEEM"}
+	usdAsset, err := result.SteemUsd.Convert(oneSteem)
+	if err != nil {
+		t.Fatalf("SteemUsd.Convert failed: %v", err)
+	}
+	usd := float64(usdAsset.Amount) / 1e3
+	if usd != 0.5 {
+		t.Errorf("steem_usd: expected 0.5, got %f (raw=%d)", usd, usdAsset.Amount)
+	}
+
+	// steem_vest: Price 100.000 STEEM / 4200000.000000 VESTS.
+	// Convert 1 STEEM → 42000 VESTS → 42000000000 (atomic, 6 decimals) → 42000.0.
+	vestAsset, err := result.SteemVest.Convert(oneSteem)
+	if err != nil {
+		t.Fatalf("SteemVest.Convert failed: %v", err)
+	}
+	vest := float64(vestAsset.Amount) / 1e6
+	// 100 STEEM = 4200000 VESTS → 1 STEEM = 42000 VESTS
+	if vest != 42000.0 {
+		t.Errorf("steem_vest: expected 42000.0, got %f (raw=%d)", vest, vestAsset.Amount)
+	}
+
+	t.Logf("steem_sbd=%f, steem_usd=%f, steem_vest=%f", sbd, usd, vest)
+}
+
+func TestPricesResponse_JSON(t *testing.T) {
+	// Verify the response struct has the correct JSON tags.
+	r := pricesResponse{SteemSbd: 0.5, SteemUsd: 0.827, SteemVest: 2019.1}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, key := range []string{`"steem_sbd"`, `"steem_usd"`, `"steem_vest"`} {
+		if !strings.Contains(s, key) {
+			t.Errorf("missing %s in JSON: %s", key, s)
+		}
+	}
+}

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -110,8 +110,10 @@ func New(cfg *config.Config) (*App, error) {
 func (a *App) registerMethods(rpc *jsonrpc.Server, blobStore store.BlobStore, db *gorm.DB) {
 	// Public methods.
 	rpc.Register("conveyor.hello", hello)
-	rpc.Register("conveyor.get_prices", prices.New(a.cfg.RpcNode).GetPrices)
 	rpc.RegisterAuthenticated("conveyor.whoami", whoami)
+
+	// Prices (steemgosdk).
+	prices.New(a.cfg.RpcNode).Register(rpc)
 
 	// Drafts (BlobStore).
 	drafts.New(blobStore, a.cfg.Name).Register(rpc)

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/steemit/conveyor/internal/featureflags"
 	"github.com/steemit/conveyor/internal/jsonrpc"
 	"github.com/steemit/conveyor/internal/models"
+	"github.com/steemit/conveyor/internal/prices"
 	"github.com/steemit/conveyor/internal/store"
 	"github.com/steemit/conveyor/internal/tags"
 	"github.com/steemit/conveyor/internal/telemetry"
@@ -109,6 +110,7 @@ func New(cfg *config.Config) (*App, error) {
 func (a *App) registerMethods(rpc *jsonrpc.Server, blobStore store.BlobStore, db *gorm.DB) {
 	// Public methods.
 	rpc.Register("conveyor.hello", hello)
+	rpc.Register("conveyor.get_prices", prices.New(a.cfg.RpcNode).GetPrices)
 	rpc.RegisterAuthenticated("conveyor.whoami", whoami)
 
 	// Drafts (BlobStore).


### PR DESCRIPTION
## Summary

M4 milestone — the `conveyor.get_prices` RPC method (public, no auth). Fetches market data from steemd in parallel and computes three price values using steemutil's integer-arithmetic `ComputePrices`.

### Implementation

- **Parallel fetch**: `GetOrderBook(1)` + `GetFeedHistory()` + `GetDynamicGlobalProperties()` via goroutines + `sync.WaitGroup` (matching TS `Promise.all`)
- **Computation**: `steemutil.ComputePrices(ob, fh, dgp)` — int64 + math/big arithmetic
- **Conversion** to schema's float64 fields:
  - `steem_sbd`: `SteemSbd.Asset.Amount / 10^3` (already the averaged conversion)
  - `steem_usd`: `SteemUsd.Price.Convert(1 STEEM).Amount / 10^3` (raw Price, needs conversion)
  - `steem_vest`: `SteemVest.Price.Convert(1 STEEM).Amount / 10^6` (raw Price, VESTS has 6 decimals)

### Note on precision

Go uses int64 + math/big (steemutil's design) vs the TS original's float64. May differ in last-digit precision — documented as acceptable in `REWRITE_PLAN.md`.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ — 2 new tests (fixture-based ComputePrices: 0.5 SBD, 0.5 USD, 42000 VESTS + JSON tags) + all M0-M3 tests pass