### PR TITLE
M7: Go Dockerfile, Makefile, .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Git
+.git
+.gitignore
+
+# Documentation
+*.md
+docs/
+
+# Development files
+.vscode/
+.idea/
+*.log
+
+# Go test files (not needed in production image)
+*_test.go
+
+# Build artifacts
+bin/
+
+# TS legacy (not used in Go version)
+src/
+test/
+tsconfig.json
+tslint.json
+package.json
+yarn.lock
+node_modules/
+lib/
+reports/
+.nyc_output/
+
+# ZCode agent workspace
+.zcode/
+
+# OS files
+.DS_Store
+Thumbs.db
+*.swp

--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,6 @@ reports/
 .DS_Store
 Thumbs.db
 *.swp
+
+# Environment secrets
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # Build stage — CGO_ENABLED=1 because mattn/go-sqlite3 requires it.
 FROM golang:1.24-alpine AS builder
 
-RUN apk add --no-cache git gcc musl-dev ca-certificates tzdata
+# Version is passed via build-arg (avoids needing .git in the build context,
+# which .dockerignore excludes). Set with: docker build --build-arg VERSION=$(git rev-parse --short HEAD)
+ARG VERSION=dev
+
+RUN apk add --no-cache gcc musl-dev ca-certificates tzdata
 
 WORKDIR /app
 
@@ -14,7 +18,7 @@ COPY . .
 
 # Build with version injection via -ldflags
 RUN CGO_ENABLED=1 GOOS=linux go build \
-    -ldflags "-X github.com/steemit/conveyor/internal/server.Version=$(git rev-parse --short HEAD 2>/dev/null || echo dev)" \
+    -ldflags "-X github.com/steemit/conveyor/internal/server.Version=${VERSION}" \
     -o conveyor ./cmd/conveyor
 
 # --- Runtime stage ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,42 @@
-FROM node:10-alpine as build-stage
+# Build stage — CGO_ENABLED=1 because mattn/go-sqlite3 requires it.
+FROM golang:1.24-alpine AS builder
+
+RUN apk add --no-cache git gcc musl-dev ca-certificates tzdata
 
 WORKDIR /app
 
-# install build dependencies
-RUN apk add --no-cache \
-    bash \
-    build-base \
-    git \
-    make \
-    python
+# Cache dependency download
+COPY go.mod go.sum ./
+RUN go mod download
 
-# install application dependencies
-COPY package.json yarn.lock ./
-RUN JOBS=max yarn install --non-interactive --frozen-lockfile
-
-# copy in application source
+# Copy source
 COPY . .
 
-# run tests and compile sources
-RUN make lib ci-test
+# Build with version injection via -ldflags
+RUN CGO_ENABLED=1 GOOS=linux go build \
+    -ldflags "-X github.com/steemit/conveyor/internal/server.Version=$(git rev-parse --short HEAD 2>/dev/null || echo dev)" \
+    -o conveyor ./cmd/conveyor
 
-# prune modules
-RUN yarn install --non-interactive --frozen-lockfile --production
+# --- Runtime stage ---
+FROM alpine:3.20
 
-# copy built application to runtime image
-FROM node:10-alpine
+RUN apk add --no-cache ca-certificates tzdata sqlite-libs
+
 WORKDIR /app
-COPY --from=build-stage /app/config config
-COPY --from=build-stage /app/lib lib
-COPY --from=build-stage /app/node_modules node_modules
-COPY --from=build-stage /app/user-data user-data
 
-# setup default env
-ENV PORT 8080
-ENV NODE_ENV production
+# Binary
+COPY --from=builder /app/conveyor .
 
-# app entrypoint
-CMD [ "node", "lib/server.js" ]
+# Runtime assets: TOML configs + account lists
+COPY --from=builder /app/config config
+COPY --from=builder /app/user-data user-data
+
+EXPOSE 8080
+
+ENV PORT=8080
+ENV NODE_ENV=production
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q --spider http://localhost:8080/ || exit 1
+
+CMD ["./conveyor"]

--- a/Makefile
+++ b/Makefile
@@ -1,184 +1,31 @@
-SHELL := /bin/bash
-PATH  := ./node_modules/.bin:$(PATH)
+# Conveyor Go Makefile
 
-SRC_FILES := $(shell find src -name '*.ts')
+BINARY := bin/conveyor
+VERSION := $(shell git rev-parse --short HEAD 2>/dev/null || echo dev)
+LDFLAGS := -X github.com/steemit/conveyor/internal/server.Version=$(VERSION)
 
-DOCS_ROOT := docs
-API_TESTS_ROOT := api-tests
-CONVEYOR_SCHEMA := conveyor_schema.json
+.PHONY: build test vet tidy devserver docker-build docker-run clean
 
-# user data and indexes
-USER_DATA_ROOT := ./user-data
+build:
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/conveyor
 
-# user accounts
-USER_ACCTS_ROOT := $(USER_DATA_ROOT)/accounts
-USER_ACCTS_FILE := $(USER_ACCTS_ROOT)/accounts.js
+test:
+	go test ./...
 
-# bad actor / GDPR user lists
-LISTS_ROOT := $(USER_DATA_ROOT)/lists
-GDPR_LISTS := raw.githubusercontent.com/steemit/condenser/master/src/app/utils/GDPRUserList.js
-LOCAL_GDPR_LISTS := $(addprefix $(LISTS_ROOT)/gdpr/srcs/, $(GDPR_LISTS))
+vet:
+	go vet ./...
 
-BAD_ACTOR_LISTS := raw.githubusercontent.com/steemit/condenser/master/src/app/utils/DMCAUserList.js \
-    raw.githubusercontent.com/steemit/condenser/master/src/app/utils/ImageUserBlockList.js \
-    raw.githubusercontent.com/steemit/condenser/master/src/app/utils/BadActorList.js \
-    raw.githubusercontent.com/steemit/redeemer-irredeemables/master/full.txt
+tidy:
+	go mod tidy
 
-LOCAL_BAD_ACTOR_LISTS := $(addprefix $(LISTS_ROOT)/bad_actors/srcs/, $(BAD_ACTOR_LISTS))
+devserver:
+	go run ./cmd/conveyor
 
-EXCHANGE_LISTS := raw.githubusercontent.com/steemit/condenser/master/src/app/utils/VerifiedExchangeList.js
-LOCAL_EXCHANGE_LISTS := $(addprefix $(LISTS_ROOT)/exchanges/srcs/, $(EXCHANGE_LISTS))
-
-VERIFIED_LISTS :=
-LOCAL_VERIFIED_LISTS := $(addprefix $(LISTS_ROOT)/verified/srcs/, $(VERIFIED_LISTS))
-
-all: lib
-
-lib: $(SRC_FILES) node_modules tsconfig.json
-	tsc -p tsconfig.json --outDir lib
-	VERSION="$$(node -p 'require("./package.json").version')"; \
-	BUILD="$$(git rev-parse --short HEAD)-$$(date +%s)"; \
-	echo "module.exports = '$${VERSION}-$${BUILD}';" > lib/version.js
-	touch lib
-
-.PHONY: devserver
-devserver: node_modules
-	@onchange -i 'src/**/*.ts' 'config/*' -- ts-node src/server.ts | bunyan -o short
-
-reports:
-	mkdir reports
-
-.PHONY: coverage
-coverage: node_modules reports
-	NODE_ENV=test nyc -r html -r text -e .ts -i ts-node/register \
-		--report-dir reports/coverage \
-		mocha --reporter nyan --require ts-node/register test/*.ts
-
-.PHONY: test
-test: node_modules
-	NODE_ENV=test mocha --require ts-node/register test/*.ts --grep '$(grep)'
-
-.PHONY: ci-test
-ci-test: node_modules reports
-	nsp check
-	tslint -p tsconfig.json -c tslint.json
-	NODE_ENV=test mocha --require ts-node/register test/*.ts --grep '$(grep)'
-
-.PHONY: lint
-lint: node_modules
-	tslint -p tsconfig.json -c tslint.json -t stylish --fix
-
-node_modules: package.json
-	yarn install --non-interactive --frozen-lockfile
-
-.PHONY: clean
-clean:
-	rm -rf lib/
-
-.PHONY: distclean
-distclean: clean
-	rm -rf node_modules/
-
-.PHONY: docker-build
-docker-build: distclean
-	find src test -iname '*.js' -delete
+docker-build:
 	docker build -t steemit/conveyor:latest .
 
-.PHONY: docker-run
 docker-run:
-	docker run -it -e S3_BUCKET=junk -p 8080:8080 steemit/conveyor:latest
+	docker run -it -p 8080:8080 steemit/conveyor:latest
 
-.PHONY:docs
-docs: $(DOCS_ROOT)/Conveyor.html $(DOCS_ROOT)/Conveyor.md
-
-$(DOCS_ROOT)/Conveyor.html: $(CONVEYOR_SCHEMA)
-	-mkdir -p $(DOCS_ROOT)
-	./node_modules/.bin/jrgen --outdir $(DOCS_ROOT) docs/html $<
-
-$(DOCS_ROOT)/Conveyor.md: $(CONVEYOR_SCHEMA)
-	-mkdir -p $(DOCS_ROOT)
-	./node_modules/.bin/jrgen --outdir $(DOCS_ROOT) docs/md $<
-
-.PHONY: clean-docs
-clean-docs:
-	-rm -rf $(DOCS_ROOT)/*
-
-.PHONY: update-docs
-update-docs: clean-docs docs
-
-.PHONY: api-tests
-api-tests: $(CONVEYOR_SCHEMA)
-	-mkdir -p $(API_TESTS_ROOT)
-	./node_modules/.bin/jrgen --outdir $(API_TESTS_ROOT) test/jasmine $<
-
-.PHONY: bad-actors-list
-bad-actors-list: $(LISTS_ROOT)/bad_actors/users.txt $(LISTS_ROOT)/bad_actors/users.json $(LISTS_ROOT)/bad_actors/users.js
-
-.PHONY: gdpr-list
-gdpr-list: $(LISTS_ROOT)/gdpr/users.txt $(LISTS_ROOT)/gdpr/users.json $(LISTS_ROOT)/gdpr/users.js
-
-.PHONY: exchanges-list
-exchanges-list: $(LISTS_ROOT)/exchanges/users.txt $(LISTS_ROOT)/exchanges/users.json $(LISTS_ROOT)/exchanges/users.js
-
-.PHONY: verified-list
-exchanges-list: $(LISTS_ROOT)/verified/users.txt $(LISTS_ROOT)/verified/users.json $(LISTS_ROOT)/verified/users.js
-
-.PHONY: user-lists
-user-lists: bad-actors-list gdpr-list exchanges-list verified-list
-
-$(LISTS_ROOT)/bad_actors/users.txt: $(LOCAL_BAD_ACTOR_LISTS)
-	cat $(LOCAL_BAD_ACTOR_LISTS) \
-	    | awk '{$$1=$$1};1' \
-	    | egrep --only-matching --line-regexp '^[\.a-zA-Z0-9_-]+$$' \
-	    | LC_COLLATE=C sort \
-	    | uniq > $@
-
-$(LISTS_ROOT)/bad_actors/srcs/%:
-	mkdir -p $(dir $@)
-	wget -O $@ https://$*
-
-$(LISTS_ROOT)/gdpr/users.txt: $(LOCAL_GDPR_LISTS)
-	cat $(LOCAL_GDPR_LISTS) \
-	    | awk '{$$1=$$1};1' \
-	    | egrep --only-matching --line-regexp '^[\.a-zA-Z0-9_-]+$$' \
-	    | LC_COLLATE=C sort \
-	    | uniq > $@
-
-$(LISTS_ROOT)/gdpr/srcs/%:
-	mkdir -p $(dir $@)
-	wget -O $@ https://$*
-
-$(LISTS_ROOT)/exchanges/users.txt: $(LOCAL_EXCHANGE_LISTS)
-	cat $(LOCAL_EXCHANGE_LISTS) \
-	    | awk '{$$1=$$1};1' \
-	    | egrep --only-matching --line-regexp '^[\.a-zA-Z0-9_-]+$$' \
-	    | LC_COLLATE=C sort \
-	    | uniq > $@
-
-$(LISTS_ROOT)/exchanges/srcs/%:
-	mkdir -p $(dir $@)
-	wget -O $@ https://$*
-
-
-$(LISTS_ROOT)/%.json: $(LISTS_ROOT)/%.txt
-	cat $< | jq -R -s -c 'split("\n")|map(select(. != ""))' > $@
-	-rm $<
-
-$(LISTS_ROOT)/%.js: $(LISTS_ROOT)/%.json
-	cat <(echo -n "module.exports = new Set(") $<  <(echo  ")") | prettier --parser typescript --stdin --no-semi --single-quote > $@
-	-rm $<
-	-rm -rf $(LISTS_ROOT)/$(*D)/srcs
-
-.PHONY: clean-lists
-clean-lists:
-	-rm -rf $(LISTS_ROOT)/gdpr/* $(LISTS_ROOT)/bad_actors/* $(LISTS_ROOT)/exchanges/*
-
-.PHONY: user-accounts
-user-accounts: $(USER_ACCTS_FILE)
-
-.PHONY: clean-user-accounts
-clean-user-accounts:
-	-rm $(USER_ACCTS_FILE)
-
-$(USER_ACCTS_FILE):
-	./node_modules/.bin/ts-node src/user-search/scripts/load_accounts.ts > $@
+clean:
+	rm -rf bin/

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ devserver:
 	go run ./cmd/conveyor
 
 docker-build:
-	docker build -t steemit/conveyor:latest .
+	docker build --build-arg VERSION=$(VERSION) -t steemit/conveyor:latest .
 
 docker-run:
 	docker run -it -p 8080:8080 steemit/conveyor:latest


### PR DESCRIPTION
## Summary

M7 milestone — the final milestone. Replaces the TS-era Docker/Makefile with Go equivalents, completing the Go rewrite.

### Changes

| File | Change |
|---|---|
| `Dockerfile` | TS `node:10-alpine` → Go multi-stage (`golang:1.24-alpine` builder + `alpine:3.20` runtime), CGO_ENABLED=1 for sqlite3 |
| `Makefile` | TS `yarn`/`tsc`/`mocha` → Go `build`/`test`/`vet`/`tidy`/`devserver`/`docker-build`/`docker-run`/`clean` |
| `.dockerignore` | TS exclusions → Go project exclusions (TS legacy, test files, build artifacts) |

### Key design decisions

- **CGO_ENABLED=1**: `mattn/go-sqlite3` (used by `gorm.io/driver/sqlite`) requires CGO. The builder stage installs `gcc musl-dev`; the runtime stage installs `sqlite-libs`.
- **Version injection**: `-ldflags "-X ...server.Version=$(git rev-parse --short HEAD)"` injects the git hash at build time (overriding the `var Version = "dev"` default in `version.go`).
- **Runtime assets**: `config/` (TOML configs) and `user-data/` (accounts.js + bad-actors/exchanges/gdpr lists) are copied into the image.

## Verification

- `go build` with `-ldflags` ✅
- `go vet` ✅
- `go test` ✅ (all M0-M6 tests pass)
- Docker build not tested in CI environment (requires Docker daemon)

## Milestone complete

With M7, the Go rewrite of conveyor is functionally complete. All 21 RPC methods are implemented across 8 subsystems, with JSON-RPC 2.0 envelope, `__signed` authentication, OpenTelemetry tracing, BlobStore, GORM models, and the Dockerfile/Makefile for production deployment.