### PR TITLE
fix(security): SSRF hardening, body-size limit, panic guard, .env ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ vendor/
 # Editor/OS
 .vscode/
 *.swp
+
+# Environment secrets
+.env

--- a/internal/jsonrpc/middleware.go
+++ b/internal/jsonrpc/middleware.go
@@ -9,6 +9,13 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// maxRequestBodyBytes caps the size of a single JSON-RPC request body.
+// JSON-RPC requests are small; this bounds memory use and prevents trivial
+// memory-exhaustion DoS. Batches are subject to the same cap. A body exceeding
+// the cap fails io.ReadAll with an *http.MaxBytesError and is surfaced as a
+// 400 ParseError by the read-error path below.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
 // Handler returns a gin.HandlerFunc that serves JSON-RPC 2.0 over POST /.
 // Behavior mirrors @steemit/koa-jsonrpc's middleware:
 //   - body parse failure -> 400 + ParseError
@@ -21,6 +28,10 @@ import (
 // internal 405 check; we rely on Gin's routing instead.
 func (s *Server) Handler(log zerolog.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Cap the request body to bound memory use. An oversized body makes
+		// io.ReadAll fail (the writer gets a 413-like signal) and flows into
+		// the same 400 ParseError path as other read failures.
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRequestBodyBytes)
 		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			respondError(c, http.StatusBadRequest, &Response{

--- a/internal/jsonrpc/middleware_test.go
+++ b/internal/jsonrpc/middleware_test.go
@@ -104,6 +104,30 @@ func TestMiddleware_ParseError_400(t *testing.T) {
 	}
 }
 
+// TestMiddleware_OversizedBody_400 verifies that a request body exceeding the
+// 1 MiB cap is rejected with a 400 ParseError (memory-exhaustion DoS defense).
+func TestMiddleware_OversizedBody_400(t *testing.T) {
+	r := setupTestRouter(t)
+	// 2 MiB body — well over the 1 MiB cap.
+	big := strings.Repeat("x", 2<<20)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(big))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized body, got %d", w.Code)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got: %v", resp)
+	}
+	if int(errObj["code"].(float64)) != ParseError {
+		t.Fatalf("expected ParseError for oversized body, got %v", errObj["code"])
+	}
+}
+
 func TestMiddleware_NonPost_NotRoutedByRPC(t *testing.T) {
 	// In this architecture, GET / is healthcheck (registered in server.app),
 	// POST / is RPC. The test router only registers POST /, so a GET / is a

--- a/internal/summarizer/safehttp.go
+++ b/internal/summarizer/safehttp.go
@@ -1,0 +1,142 @@
+// This file implements the SSRF defenses for conveyor.summarize_url.
+//
+// summarize_url is a *public* (unauthenticated) endpoint that fetches an
+// attacker-supplied URL. Without the controls here, an attacker could make
+// conveyor issue requests to internal addresses (loopback, link-local such as
+// the AWS IMDS endpoint 169.254.169.254, RFC1918 ranges) — either to read
+// internal/metadata services or to use conveyor as a fetch amplifier.
+//
+// Defenses:
+//   - validateScheme: only http/https (entrypoint and each redirect hop).
+//   - safeDialContext: resolves the host itself, validates EVERY resolved IP
+//     before connecting, and connects to the already-validated IP literal. No
+//     second DNS lookup occurs, so a DNS rebinding attack (valid IP at check
+//     time, private IP at connect time) cannot succeed.
+//   - newSafeTransport wires the dialer into http.Transport.
+package summarizer
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// errBlockedScheme is returned for non-http(s) URLs (including file://, which
+// could otherwise read local files via goquery in some configurations).
+var errBlockedScheme = errors.New("blocked URL scheme: only http and https are allowed")
+
+// validateScheme rejects any scheme other than http/https. It is applied at the
+// entrypoint and on every redirect hop.
+func validateScheme(u *url.URL) error {
+	if u == nil {
+		return errors.New("nil URL")
+	}
+	s := strings.ToLower(u.Scheme)
+	if s != "http" && s != "https" {
+		return errBlockedScheme
+	}
+	return nil
+}
+
+// isBlockedIP reports whether the IP is in a range that must not be reached
+// from an unauthenticated URL-fetch endpoint. This covers:
+//   - loopback (127.0.0.0/8, ::1)
+//   - private / RFC1918 (10/8, 172.16/12, 192.168/16, fc00::/7)
+//   - link-local (169.254/16 incl. AWS IMDS, fe80::/10)
+//   - unspecified (0.0.0.0, ::)
+//   - multicast (224/4, ff00::/8)
+//
+// IPv4-in-IPv6 mapped addresses (::ffff:127.0.0.1) are normalized via To4() so
+// they are caught by the IPv4 checks.
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true // treat unparseable as blocked
+	}
+	// Normalize mapped IPv6 -> IPv4 so ::ffff:127.0.0.1 matches loopback.
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsUnspecified() || ip.IsMulticast() {
+		return true
+	}
+	return false
+}
+
+// safeDialContext is the SSRF-resistant dialer. It splits host:port, resolves
+// the host itself, validates all resolved IPs, and then dials the first valid
+// IP literal directly. The standard net.Dialer would re-resolve the hostname,
+// opening a DNS-rebinding window between our check and the actual connect.
+//
+// We connect to the IP (not the hostname) and rely on the default behavior for
+// Host/SNI: HTTP clients passing an IP-based authority preserve TLS SNI from
+// the request's Host header. For the common (hostname) case this is correct
+// because the transport dials the IP we validated.
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	ips, err := resolveAndValidate(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	// Dial the first validated IP. We pass an IP literal so no further DNS
+	// resolution happens. This is the core rebinding defense.
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+}
+
+// resolveAndValidate resolves host and returns the set of IPs, but only if
+// EVERY one of them passes isBlockedIP. If host is already a literal IP it is
+// validated directly without any DNS lookup.
+func resolveAndValidate(ctx context.Context, host string) ([]net.IP, error) {
+	// Literal IP — validate directly, no DNS.
+	if ip := net.ParseIP(host); ip != nil {
+		if isBlockedIP(ip) {
+			return nil, errors.New("blocked destination IP: " + host)
+		}
+		return []net.IP{ip}, nil
+	}
+
+	// Hostname — resolve and require ALL addresses to be non-internal. Allowing
+	// even one private address would let an attacker publish a DNS record that
+	// mixes public + private to slip through a "first record" check.
+	resolver := net.DefaultResolver
+	ips, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, errors.New("no IP addresses resolved for " + host)
+	}
+	out := make([]net.IP, 0, len(ips))
+	for _, ia := range ips {
+		if isBlockedIP(ia.IP) {
+			return nil, errors.New("blocked destination IP for " + host + ": " + ia.IP.String())
+		}
+		out = append(out, ia.IP)
+	}
+	return out, nil
+}
+
+// maxRedirects caps redirect chains. The http.Client default is 10; we make it
+// explicit and re-validate the scheme of every hop via CheckRedirect.
+const maxRedirects = 10
+
+// newSafeTransport returns an http.RoundTripper whose dialer resolves and
+// validates destination IPs (blocking loopback / private / link-local / etc.)
+// and connects to a pre-validated IP literal so DNS rebinding cannot occur.
+func newSafeTransport() http.RoundTripper {
+	return &http.Transport{
+		DialContext:     safeDialContext,
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: nil,
+	}
+}

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -5,6 +5,8 @@
 package summarizer
 
 import (
+	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -20,6 +22,10 @@ const (
 	cacheSize   = 10000
 	cacheTTL    = 1 * time.Hour
 	fetchTimeout = 2 * time.Second
+	// maxResponseBytes bounds the fetched body. summarize_url reads untrusted
+	// remote HTML; without a cap a malicious server could stream gigabytes and
+	// exhaust memory. 1 MiB is ample for metadata extraction from a page.
+	maxResponseBytes int64 = 1 << 20 // 1 MiB
 )
 
 // summarizedURL is the RPC result, matching the TS SummarizedUrl interface
@@ -51,7 +57,8 @@ type Summarizer struct {
 	client *http.Client
 }
 
-// New creates a Summarizer with a fresh LRU cache and 2s-timeout HTTP client.
+// New creates a Summarizer with a fresh LRU cache and an SSRF-safe HTTP client
+// (2s timeout, private-IP blocking, scheme validation on every redirect).
 func New() *Summarizer {
 	c, _ := lru.New[string, *cacheEntry](cacheSize)
 	return &Summarizer{
@@ -59,9 +66,27 @@ func New() *Summarizer {
 		client: &http.Client{
 			Timeout: fetchTimeout,
 			// Many sites block the default Go User-Agent; set a descriptive one.
-			Transport: &userAgentTransport{base: http.DefaultTransport},
+			// The underlying transport resolves and validates IPs before
+			// connecting (see newSafeTransport / safeDialContext).
+			Transport: &userAgentTransport{base: newSafeTransport()},
+			// Re-validate the scheme on every redirect hop and bound the chain.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= maxRedirects {
+					return errors.New("too many redirects")
+				}
+				return validateScheme(req.URL)
+			},
 		},
 	}
+}
+
+// newWithClient builds a Summarizer backed by the given HTTP client. It is the
+// test seam that lets tests point summarizer at a loopback httptest server
+// (which the production SSRF dialer would refuse) without weakening the
+// production path.
+func newWithClient(c *http.Client) *Summarizer {
+	cache, _ := lru.New[string, *cacheEntry](cacheSize)
+	return &Summarizer{cache: cache, client: c}
 }
 
 // userAgentTransport wraps an http.RoundTripper to inject a User-Agent header
@@ -103,6 +128,10 @@ func (s *Summarizer) SummarizeUrl(ctx *jsonrpc.Context, req *jsonrpc.Request) (a
 	if err != nil || parsed.Host == "" {
 		return nil, jsonrpc.NewError(400, nil, "Cannot parse URL")
 	}
+	// Scheme allowlist (defends against file:/// etc. before any fetch).
+	if err := validateScheme(parsed); err != nil {
+		return nil, jsonrpc.NewError(400, nil, "Cannot parse URL")
+	}
 
 	// Blacklist check.
 	blacklisted := isBlacklisted(parsed.Host, parsed.Path)
@@ -122,8 +151,12 @@ func (s *Summarizer) SummarizeUrl(ctx *jsonrpc.Context, req *jsonrpc.Request) (a
 	}
 	defer resp.Body.Close()
 
+	// Cap the fetched body so a malicious/redirected server cannot stream
+	// gigabytes into memory. The reader is scoped to this fetch only.
+	body := io.LimitReader(resp.Body, maxResponseBytes)
+
 	// Parse HTML and extract metadata via goquery.
-	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	doc, err := goquery.NewDocumentFromReader(body)
 	if err != nil {
 		return nil, jsonrpc.NewError(400, nil, "Cannot parse HTML")
 	}

--- a/internal/summarizer/summarizer_test.go
+++ b/internal/summarizer/summarizer_test.go
@@ -1,12 +1,25 @@
 package summarizer
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/steemit/conveyor/internal/jsonrpc"
 )
+
+// newTestSummarizer returns a Summarizer whose HTTP client uses the default
+// transport. The production client blocks loopback (SSRF defense), but
+// httptest servers listen on 127.0.0.1, so tests that need to hit a local
+// fixture server use this seam instead.
+func newTestSummarizer() *Summarizer {
+	return newWithClient(&http.Client{
+		Timeout:   fetchTimeout,
+		Transport: http.DefaultTransport,
+	})
+}
 
 func TestIsBlacklisted_Domain(t *testing.T) {
 	if !isBlacklisted("evil.bad.domain", "/path") {
@@ -50,7 +63,7 @@ func TestSummarizeUrl_BlacklistedDomain_StillFetched(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := New()
+	s := newTestSummarizer()
 	req := &jsonrpc.Request{Params: []byte(`{"url":"` + srv.URL + `"}`)}
 	result, err := s.SummarizeUrl(&jsonrpc.Context{}, req)
 	if err != nil {
@@ -79,7 +92,7 @@ func TestSummarizeUrl_MetadataExtraction(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := New()
+	s := newTestSummarizer()
 	req := &jsonrpc.Request{Params: []byte(`{"url":"` + srv.URL + `"}`)}
 	result, err := s.SummarizeUrl(&jsonrpc.Context{}, req)
 	if err != nil {
@@ -119,7 +132,7 @@ func TestSummarizeUrl_CacheHit(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := New()
+	s := newTestSummarizer()
 	req := &jsonrpc.Request{Params: []byte(`{"url":"` + srv.URL + `"}`)}
 
 	// First call — fetches from server.
@@ -164,6 +177,109 @@ func TestSummarizeUrl_FetchFailure(t *testing.T) {
 	_, err := s.SummarizeUrl(&jsonrpc.Context{}, req)
 	if err == nil {
 		t.Fatal("expected fetch error")
+	}
+	e, ok := err.(*jsonrpc.Error)
+	if !ok || e.Code != 400 {
+		t.Fatalf("expected 400, got %v", err)
+	}
+}
+
+// --- SSRF defense tests ---
+
+func TestIsBlockedIP(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1", "127.1.2.3",           // loopback
+		"10.0.0.1", "192.168.1.1",          // RFC1918
+		"172.16.0.1", "172.31.255.255",     // RFC1918 172.16/12
+		"169.254.169.254",                  // link-local / AWS IMDS
+		"0.0.0.0",                          // unspecified
+		"::1",                              // IPv6 loopback
+		"::ffff:127.0.0.1",                 // IPv4-in-IPv6 mapped loopback
+		"fe80::1",                          // IPv6 link-local
+		"fc00::1",                          // IPv6 ULA/private
+	}
+	for _, s := range blocked {
+		if !isBlockedIP(parseIP(t, s)) {
+			t.Errorf("expected %s to be blocked", s)
+		}
+	}
+	allowed := []string{
+		"8.8.8.8", "1.1.1.1",               // public
+		"93.184.216.34",                    // example.com
+		"2606:4700:4700::1111",             // public IPv6
+	}
+	for _, s := range allowed {
+		if isBlockedIP(parseIP(t, s)) {
+			t.Errorf("expected %s to be allowed", s)
+		}
+	}
+}
+
+func parseIP(t *testing.T, s string) net.IP {
+	t.Helper()
+	ip := net.ParseIP(s)
+	if ip == nil {
+		t.Fatalf("bad test IP literal: %s", s)
+	}
+	return ip
+}
+
+// TestSafeDialContext_RefusesPrivate verifies that dialing a literal private IP
+// is refused outright (the entrypoint IP-validation path).
+func TestSafeDialContext_RefusesPrivate(t *testing.T) {
+	cases := []string{
+		"127.0.0.1:80",        // loopback
+		"169.254.169.254:80",  // AWS IMDS
+		"10.0.0.1:80",         // RFC1918
+		"192.168.1.1:80",
+	}
+	for _, addr := range cases {
+		conn, err := safeDialContext(context.Background(), "tcp", addr)
+		if err == nil {
+			if conn != nil {
+				conn.Close()
+			}
+			t.Errorf("expected dial to %s to be refused, but it succeeded", addr)
+		}
+	}
+}
+
+// TestSummarizeUrl_NonHTTPScheme verifies that non-http(s) schemes are rejected
+// before any network activity (defends against file:/// reading local files).
+func TestSummarizeUrl_NonHTTPScheme(t *testing.T) {
+	s := New()
+	for _, u := range []string{
+		"file:///etc/passwd",
+		"ftp://example.com/",
+		"gopher://example.com/",
+	} {
+		req := &jsonrpc.Request{Params: []byte(`{"url":"` + u + `"}`)}
+		_, err := s.SummarizeUrl(&jsonrpc.Context{}, req)
+		if err == nil {
+			t.Fatalf("expected error for scheme of %s", u)
+		}
+		e, ok := err.(*jsonrpc.Error)
+		if !ok || e.Code != 400 {
+			t.Fatalf("expected 400 for %s, got %v", u, err)
+		}
+	}
+}
+
+// TestSummarizeUrl_LoopbackBlockedByProductionClient confirms the production
+// Summarizer (New, with the SSRF dialer) cannot reach a loopback httptest
+// server, even though the test-seam one can. This is the negative-control
+// counterpart to the newTestSummarizer() tests above.
+func TestSummarizeUrl_LoopbackBlockedByProductionClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("<html><title>should not be reached</title></html>"))
+	}))
+	defer srv.Close()
+
+	s := New() // production client: blocks loopback
+	req := &jsonrpc.Request{Params: []byte(`{"url":"` + srv.URL + `"}`)}
+	_, err := s.SummarizeUrl(&jsonrpc.Context{}, req)
+	if err == nil {
+		t.Fatal("expected production client to refuse loopback URL, but it succeeded")
 	}
 	e, ok := err.(*jsonrpc.Error)
 	if !ok || e.Code != 400 {

--- a/internal/userdata/userdata.go
+++ b/internal/userdata/userdata.go
@@ -86,17 +86,26 @@ func (u *UserData) setUserData(ctx *jsonrpc.Context, req *jsonrpc.Request) (any,
 		return nil, e
 	}
 
-	// Extract and validate email/phone.
+	// Extract and validate email/phone. Guard the type assertions: a non-string
+	// value (e.g. {"email": 123}) must yield a clean 400, not a panic.
 	var email, phone *string
 	if v, ok := p.UserData["email"]; ok && v != nil {
-		s := strings.TrimSpace(v.(string))
+		s, ok := v.(string)
+		if !ok {
+			return nil, jsonrpc.NewError(400, nil, "Invalid email: must be a string")
+		}
+		s = strings.TrimSpace(s)
 		if !emailPattern.MatchString(s) {
 			return nil, jsonrpc.NewError(400, nil, "Invalid email format")
 		}
 		email = &s
 	}
 	if v, ok := p.UserData["phone"]; ok && v != nil {
-		s := strings.TrimSpace(v.(string))
+		s, ok := v.(string)
+		if !ok {
+			return nil, jsonrpc.NewError(400, nil, "Invalid phone: must be a string")
+		}
+		s = strings.TrimSpace(s)
 		if !phonePattern.MatchString(s) {
 			return nil, jsonrpc.NewError(400, nil, "Invalid phone format: must be +[0-9]+")
 		}

--- a/internal/userdata/userdata_test.go
+++ b/internal/userdata/userdata_test.go
@@ -108,6 +108,34 @@ func TestSetUserData_InvalidPhone(t *testing.T) {
 	}
 }
 
+// TestSetUserData_NonStringEmail verifies that a non-string email value does
+// not panic and returns a clean 400 (previously v.(string) would panic).
+func TestSetUserData_NonStringEmail(t *testing.T) {
+	u := testUserData(t)
+	_, err := u.setUserData(userCtx("alice"), &jsonrpc.Request{Params: []byte(`{"account":"alice","userData":{"email":123}}`)})
+	if err == nil {
+		t.Fatal("expected error for non-string email")
+	}
+	e, ok := err.(*jsonrpc.Error)
+	if !ok || e.Code != 400 {
+		t.Fatalf("expected 400, got %v", err)
+	}
+}
+
+// TestSetUserData_NonStringPhone verifies that a non-string phone value does
+// not panic and returns a clean 400.
+func TestSetUserData_NonStringPhone(t *testing.T) {
+	u := testUserData(t)
+	_, err := u.setUserData(userCtx("alice"), &jsonrpc.Request{Params: []byte(`{"account":"alice","userData":{"phone":456}}`)})
+	if err == nil {
+		t.Fatal("expected error for non-string phone")
+	}
+	e, ok := err.(*jsonrpc.Error)
+	if !ok || e.Code != 400 {
+		t.Fatalf("expected 400, got %v", err)
+	}
+}
+
 func TestIsEmailRegistered(t *testing.T) {
 	u := testUserData(t)
 	u.setUserData(adminCtx(), &jsonrpc.Request{Params: []byte(`{"account":"alice","userData":{"email":"alice@example.com"}}`)})


### PR DESCRIPTION
## Summary

Four focused security fixes from the `next`-branch (Go rewrite) audit. Each change is local, covered by tests, and touches no handler business logic or dependencies. `go build` / `go vet` / `go test ./...` all pass.

| # | Severity | Fix |
|---|----------|-----|
| 1 | High | SSRF defense for the public, unauthenticated `conveyor.summarize_url` endpoint |
| 3 | Medium | Request body size cap (1 MiB) in the RPC middleware |
| 5 | Medium | Guarded type assertions in `userdata.setUserData` (panic → clean 400) |
| 2 | High (preventive) | Add `.env` to `.gitignore` |

---

## 1. SSRF defense — `conveyor.summarize_url`

`summarize_url` is **public (no auth)** and previously fetched an attacker-supplied URL with an unbounded `http.Client` — reachable internal/metadata endpoints (`127.0.0.1`, AWS IMDS `169.254.169.254`, RFC1918), followed redirects, and had no response-size cap.

**`internal/summarizer/safehttp.go`** (new):
- `validateScheme` — only `http`/`https` (blocks `file:///`, `ftp://`, etc.); applied at entrypoint and each redirect hop.
- `isBlockedIP` — rejects loopback / RFC1918 / link-local (incl. AWS IMDS) / unspecified / multicast, with IPv4-in-IPv6 normalization.
- `safeDialContext` — **DNS rebinding defense**: resolves the host itself, validates **every** resolved IP, then connects to a pre-validated IP literal (no second DNS lookup, so a record cannot rebind to a private address between check and connect).
- `newSafeTransport` — wires the dialer into `http.Transport`.

**`internal/summarizer/summarizer.go`**:
- Production client uses `newSafeTransport` + `CheckRedirect` (≤10 hops, scheme re-validated per hop).
- Response body capped at 1 MiB via `io.LimitReader`.
- Entrypoint scheme validated before any fetch.
- Test seam `newWithClient` lets tests hit loopback `httptest` servers (which the production dialer refuses) without weakening prod.

## 3. Request body size limit (1 MiB) — `internal/jsonrpc/middleware.go`

`io.ReadAll(c.Request.Body)` was unbounded — a single oversized POST could exhaust memory. Wrapped in `http.MaxBytesReader(1 MiB)`; oversized bodies surface as `400 ParseError` through the existing read-error path.

## 5. Type-assertion panic guard — `internal/userdata/userdata.go`

`v.(string)` on `email`/`phone` panicked on non-string input (e.g. `{"email":123}`). Now uses comma-ok form and returns a clean `400`.

## 2. `.env` in `.gitignore`

Prevents **future** working-tree copies from being committed.

---

## Test coverage

New tests (all passing):
- `TestIsBlockedIP` — loopback / RFC1918 / link-local / mapped-IPv6 / public
- `TestSafeDialContext_RefusesPrivate` — literal private-IP dial refusal
- `TestSummarizeUrl_NonHTTPScheme` — `file://`, `ftp://`, `gopher://` rejected
- `TestSummarizeUrl_LoopbackBlockedByProductionClient` — prod client cannot reach loopback
- `TestMiddleware_OversizedBody_400` — 2 MiB body → 400 ParseError
- `TestSetUserData_NonStringEmail` / `TestSetUserData_NonStringPhone` — non-string → 400, no panic

Existing `httptest`-based summarizer tests switched to a test-seam client (loopback) since the production dialer now correctly refuses loopback.

---

## ⚠️ Explicitly out of scope (needs separate work)

1. **History-buried `.env` leak.** The key `5KNq...` was committed in `2295bef` (2018) and remains in git history reachable from `master`/`origin/master`. This PR's `.gitignore` only blocks future copies. Full cleanup needs `git filter-repo --invert-paths --path .env` + force-push across branches — a history rewrite that requires separate approval.
2. **On-chain key rotation of `test-safari`** — treated the exposed key as compromised.
3. **Remaining audit findings** — rate limiting (#4), trusted-proxy config (#6), DB error leakage (#7), nonce replay (#8), placeholder blacklist (#9). Each has prerequisites (e.g. #6 needs the production LB CIDR) and should be evaluated separately.