### PR TITLE
ci: GitHub Action for Docker build-and-deploy, drop CircleCI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,55 @@
+name: build-and-deploy
+
+on:
+  push:
+    branches:
+      - 'master'
+  workflow_dispatch:
+
+jobs:
+  docker:
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Get commit SHA short
+        id: commit
+        run: echo "sha7=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          tags: |
+            steemit/conveyor:latest
+            steemit/conveyor:latest-${{ steps.commit.outputs.sha7 }}
+          build-args: |
+            VERSION=${{ steps.commit.outputs.sha7 }}
+      -
+        name: Image info
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          echo "=== Docker Image Information ==="
+          echo "Image: steemit/conveyor"
+          echo "Tags:"
+          echo "  - steemit/conveyor:latest"
+          echo "  - steemit/conveyor:latest-${{ steps.commit.outputs.sha7 }}"
+          echo "Digest: ${{ steps.docker_build.outputs.digest }}"
+          echo "================================"


### PR DESCRIPTION
## Summary

Replace CircleCI (which only ran `docker build` without pushing) with a GitHub Action that builds and pushes to DockerHub. Mirrors the [imagehoster](https://github.com/steemit/imagehoster) / [openresty](https://github.com/steemit/openresty) CI pattern.

## What the Action does

- **Trigger:** push to `master` (+ manual `workflow_dispatch`)
- **Build:** multi-arch (QEMU + Buildx), uses the existing multi-stage Dockerfile
- **Push:** two tags — `steemit/conveyor:latest` and `steemit/conveyor:latest-<sha7>`
- **VERSION:** injects `--build-arg VERSION=<sha7>` so the binary's healthcheck reports the commit

## Why `master` not `next`

The Go rewrite currently lives on `next`; `master` is the old TS codebase. After this PR merges to `next`, a separate `next → master` merge will activate the CI and remove `.circleci/config.yml` (which exists only on `master`).

## CircleCI removal

- `.circleci/config.yml` was never tracked on `next` (only on `master`).
- The old CircleCI config ran `docker build .` **without** `docker push`, so images were never published — the new Action fixes this.
- The `next → master` merge will cleanly drop `.circleci/` since `next` doesn't track it.

## Prerequisites

The `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets must be set on the `steemit/conveyor` repo (same as imagehoster/openresty). Please verify before the master merge.